### PR TITLE
Update README and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 
 This is a FastAPI-based MCP server that exposes MLB and Fangraphs baseball data via the [pybaseball](https://pypi.org/project/pybaseball/) library.
+The `pybaseball` package relies on common scientific Python libraries such as pandas and numpy.
 
 ## Features
 - `/player?name=...` — Get player Statcast data by name (optionally filter by date range)
@@ -29,7 +30,13 @@ uvicorn main:app --reload
 One up and running, interactive API docs are available at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs).
 
 ## Publishing
-This project is ready for deployment on Smithery or any other MCP-compatible platform. It uses only pure Python dependencies for easy deployment.
+To expose an MCP STDIO interface instead of HTTP, first start the FastAPI server and then run the wrapper:
+```bash
+uvicorn main:app --host 0.0.0.0 --port 8000 &
+python mcp_stdio_wrapper.py
+```
+
+This project is ready for deployment on Smithery or any other MCP-compatible platform. It uses the `pybaseball` library and its dependencies, including pandas and numpy.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ fastapi
 uvicorn
 pybaseball
 requests
-PyYAML
 pyyaml

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,4 +1,6 @@
 # Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
 
+# For deployments that expect MCP STDIO, start uvicorn and then run the wrapper:
+# start: bash -c "uvicorn main:app --host 0.0.0.0 --port 8000 --log-config /app/uvicorn_log_config.json & python mcp_stdio_wrapper.py"
 start: uvicorn main:app --host 0.0.0.0 --port 8000 --log-config /app/uvicorn_log_config.json
 port: 8000


### PR DESCRIPTION
## Summary
- clarify pybaseball's dependencies in README
- document how to run with the MCP STDIO wrapper
- mention STDIO wrapper in smithery config
- remove duplicate requirement

## Testing
- `./test_mcp_stdio.sh` *(fails: uvicorn and requests not available)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f7a01ac83239e9db63b4510f84e