### PR TITLE
Use STDIO wrapper in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 EXPOSE 8000
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["bash", "-c", "uvicorn main:app --host 0.0.0.0 --port 8000 --log-config /app/uvicorn_log_config.json & python mcp_stdio_wrapper.py"]


### PR DESCRIPTION
## Summary
- start FastAPI and run `mcp_stdio_wrapper.py` from Docker

## Testing
- `pip install -r requirements.txt`
- `./test_mcp_stdio.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f706a43488323afcb1e5d18814b1b