### PR TITLE
Use STDIO wrapper in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 EXPOSE 8000
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+ENV FASTAPI_STARTUP_RETRIES=120
+CMD ["bash", "-c", "uvicorn main:app --host 0.0.0.0 --port 8000 --log-config /app/uvicorn_log_config.json & python mcp_stdio_wrapper.py"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ uvicorn main:app --host 0.0.0.0 --port 8000 &
 python mcp_stdio_wrapper.py
 ```
 
+The wrapper waits for the FastAPI server to become ready. Adjust the startup wait period by setting the `FASTAPI_STARTUP_RETRIES` environment variable (default: 120 retries at 0.5 seconds each).
+
 This project is ready for deployment on Smithery or any other MCP-compatible platform. It uses the `pybaseball` library and its dependencies, including pandas and numpy.
 
 ---

--- a/mcp_stdio_wrapper.py
+++ b/mcp_stdio_wrapper.py
@@ -2,11 +2,13 @@ import sys
 import json
 import requests
 import time
+import os
 
-FASTAPI_URL = "http://localhost:8000"
+FASTAPI_URL = os.getenv("FASTAPI_URL", "http://localhost:8000")
+retries = int(os.getenv("FASTAPI_STARTUP_RETRIES", "120"))
 
 # Wait for FastAPI to be ready
-for _ in range(20):  # Try for up to 10 seconds
+for _ in range(retries):
     try:
         r = requests.get(f"{FASTAPI_URL}/docs", timeout=0.5)
         if r.status_code == 200:

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -3,4 +3,6 @@
 # For deployments that expect MCP STDIO, start uvicorn and then run the wrapper:
 # start: bash -c "uvicorn main:app --host 0.0.0.0 --port 8000 --log-config /app/uvicorn_log_config.json & python mcp_stdio_wrapper.py"
 start: bash -c "uvicorn main:app --host 0.0.0.0 --port 8000 --log-config /app/uvicorn_log_config.json & python mcp_stdio_wrapper.py"
+env:
+  FASTAPI_STARTUP_RETRIES: "120"
 port: 8000


### PR DESCRIPTION
## Summary
- start FastAPI and run `mcp_stdio_wrapper.py` from Docker
- allow longer FastAPI startup wait via env vars
- document startup wait tuning in README
- configure smithery environment for the wrapper

## Testing
- `pip install -r requirements.txt`
- `./test_mcp_stdio.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f706a43488323afcb1e5d18814b1b