### PR TITLE
Fix httpx version for successful Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage Dockerfile for Smithery-compatible MCP server
-FROM python:3.11-slim-bookworm as builder
+FROM python:3.11-slim-bookworm AS builder
 
 # Install build tools and libraries needed for packages like pandas and lxml
 RUN apt-get update && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ requests==2.32.4
 pyyaml==6.0.2
 # Additional dependencies that might be needed
 python-multipart==0.0.16
-httpx==0.29.0
+httpx==0.28.1


### PR DESCRIPTION
## Summary
Fixed incorrect httpx version that was causing Docker build failures.

## Changes
- Changed `httpx==0.29.0` to `httpx==0.28.1` (0.29.0 doesn't exist)
- Fixed Dockerfile `FROM AS` casing warning

## Test Results
- ✅ Docker build succeeds
- ✅ Container runs successfully
- ✅ Health endpoints respond correctly

## Error Fixed
```
ERROR: Could not find a version that satisfies the requirement httpx==0.29.0
ERROR: No matching distribution found for httpx==0.29.0
```

This was preventing the Smithery deployment from building successfully.