### PR TITLE
fix: create minimal test implementation for Smithery tool listing

### DIFF
--- a/Dockerfile.smithery
+++ b/Dockerfile.smithery
@@ -1,0 +1,20 @@
+# Smithery-specific Dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install minimal dependencies
+RUN pip install --no-cache-dir fastapi uvicorn
+
+# Copy application
+COPY main_smithery.py ./main.py
+
+# Create non-root user
+RUN useradd -m -s /bin/bash app && chown -R app:app /app
+USER app
+
+# Environment
+ENV PYTHONUNBUFFERED=1
+
+# Start server
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,20 @@
+# Test Dockerfile for Smithery
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+RUN pip install --no-cache-dir fastapi uvicorn
+
+# Copy app
+COPY main_test.py ./main.py
+
+# Create non-root user
+RUN useradd -m app && chown -R app:app /app
+USER app
+
+# Smithery sets PORT environment variable
+EXPOSE 8000
+
+# Use shell form to expand PORT variable
+CMD sh -c "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"

--- a/main_dynamic.py
+++ b/main_dynamic.py
@@ -1,0 +1,126 @@
+"""
+MCP server with dynamic tool listing for Smithery.
+"""
+from fastapi import FastAPI, Request
+from datetime import datetime
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("mlb_mcp")
+
+app = FastAPI()
+
+# Tool definitions
+TOOLS = [
+    {
+        "name": "get_player_stats",
+        "description": "Get player statcast data by name",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Player name"},
+                "start_date": {"type": "string", "description": "Start date YYYY-MM-DD"},
+                "end_date": {"type": "string", "description": "End date YYYY-MM-DD"}
+            },
+            "required": ["name"]
+        }
+    },
+    {
+        "name": "get_team_stats",
+        "description": "Get team stats for a given team and year",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "team": {"type": "string", "description": "Team name or abbreviation"},
+                "year": {"type": "integer", "description": "Year/season"},
+                "type": {"type": "string", "enum": ["batting", "pitching"]}
+            },
+            "required": ["team", "year", "type"]
+        }
+    },
+    {
+        "name": "get_leaderboard",
+        "description": "Get leaderboard for a stat and season",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "stat": {"type": "string", "description": "Statistic (e.g., HR, AVG, ERA)"},
+                "season": {"type": "integer", "description": "Season year"},
+                "type": {"type": "string", "enum": ["batting", "pitching"]}
+            },
+            "required": ["stat", "season"]
+        }
+    },
+    {
+        "name": "statcast_leaderboard",
+        "description": "Get Statcast leaderboard for date range",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "start_date": {"type": "string"},
+                "end_date": {"type": "string"},
+                "limit": {"type": "integer", "default": 10},
+                "min_ev": {"type": "number"},
+                "result": {"type": "string"},
+                "order": {"type": "string", "enum": ["asc", "desc"], "default": "desc"}
+            },
+            "required": ["start_date", "end_date"]
+        }
+    }
+]
+
+@app.get("/health")
+async def health():
+    return {"status": "healthy"}
+
+@app.post("/")
+async def handle_mcp(request: Request):
+    """Main MCP endpoint"""
+    body = await request.json()
+    method = body.get("method")
+    params = body.get("params", {})
+    request_id = body.get("id")
+    
+    logger.info(f"MCP request: {method}")
+    
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "mlb_mcp", "version": "1.0.0"}
+            },
+            "id": request_id
+        }
+    
+    elif method == "tools/list":
+        return {
+            "jsonrpc": "2.0",
+            "result": {"tools": TOOLS},
+            "id": request_id
+        }
+    
+    elif method == "tools/call":
+        tool = params.get("name")
+        args = params.get("arguments", {})
+        
+        # Simple placeholder responses
+        result_text = f"Called {tool} with {json.dumps(args)}"
+        
+        return {
+            "jsonrpc": "2.0",
+            "result": {
+                "content": [{"type": "text", "text": result_text}]
+            },
+            "id": request_id
+        }
+    
+    else:
+        return {
+            "jsonrpc": "2.0",
+            "error": {"code": -32601, "message": f"Method not found: {method}"},
+            "id": request_id
+        }

--- a/main_smithery.py
+++ b/main_smithery.py
@@ -1,0 +1,169 @@
+"""
+Minimal MCP server for Smithery deployment.
+Tools are defined in smithery.yaml, so we just need to handle execution.
+"""
+from fastapi import FastAPI, Request, HTTPException
+from datetime import datetime
+import os
+import json
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("mlb_mcp")
+
+app = FastAPI(title="MLB Stats MCP")
+
+@app.on_event("startup")
+async def startup_event():
+    logger.info("MLB Stats MCP server starting...")
+    logger.info(f"PORT: {os.environ.get('PORT', 'Not set')}")
+
+# Health check
+@app.get("/")
+async def root():
+    return {"status": "ok", "message": "MLB Stats MCP server is running"}
+
+@app.get("/health")
+async def health():
+    return {"status": "healthy", "timestamp": datetime.now().isoformat()}
+
+# MCP JSON-RPC endpoint
+@app.post("/")
+async def handle_jsonrpc(request: Request):
+    """Main JSON-RPC endpoint for MCP protocol"""
+    try:
+        body = await request.json()
+        method = body.get("method")
+        params = body.get("params", {})
+        request_id = body.get("id")
+        
+        logger.info(f"Received: method={method}, id={request_id}")
+        
+        if method == "initialize":
+            return {
+                "jsonrpc": "2.0",
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {
+                        "tools": {}
+                    },
+                    "serverInfo": {
+                        "name": "mlb_mcp",
+                        "version": "1.0.0"
+                    }
+                },
+                "id": request_id
+            }
+        
+        elif method == "tools/list":
+            # Return empty list - tools are defined in smithery.yaml
+            return {
+                "jsonrpc": "2.0",
+                "result": {
+                    "tools": []
+                },
+                "id": request_id
+            }
+        
+        elif method == "tools/call":
+            tool_name = params.get("name")
+            arguments = params.get("arguments", {})
+            
+            logger.info(f"Tool call: {tool_name} with args: {arguments}")
+            
+            # Simple responses for each tool
+            if tool_name == "get_player_stats":
+                player_name = arguments.get("name", "Unknown")
+                return {
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": f"Player stats for {player_name}: Implementation coming soon. This tool will return batting statistics from MLB/Fangraphs."
+                            }
+                        ]
+                    },
+                    "id": request_id
+                }
+            
+            elif tool_name == "get_team_stats":
+                team = arguments.get("team", "Unknown")
+                year = arguments.get("year", 2024)
+                stat_type = arguments.get("type", "batting")
+                return {
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": f"Team {stat_type} stats for {team} in {year}: Implementation coming soon."
+                            }
+                        ]
+                    },
+                    "id": request_id
+                }
+            
+            elif tool_name == "get_leaderboard":
+                stat = arguments.get("stat", "HR")
+                season = arguments.get("season", 2024)
+                return {
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": f"Leaderboard for {stat} in {season}: Implementation coming soon."
+                            }
+                        ]
+                    },
+                    "id": request_id
+                }
+            
+            elif tool_name == "statcast_leaderboard":
+                start_date = arguments.get("start_date")
+                end_date = arguments.get("end_date")
+                return {
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": f"Statcast leaderboard from {start_date} to {end_date}: Implementation coming soon."
+                            }
+                        ]
+                    },
+                    "id": request_id
+                }
+            
+            else:
+                return {
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "code": -32601,
+                        "message": f"Unknown tool: {tool_name}"
+                    },
+                    "id": request_id
+                }
+        
+        else:
+            return {
+                "jsonrpc": "2.0",
+                "error": {
+                    "code": -32601,
+                    "message": f"Method not found: {method}"
+                },
+                "id": request_id
+            }
+            
+    except Exception as e:
+        logger.error(f"Error: {str(e)}")
+        return {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32603,
+                "message": str(e)
+            },
+            "id": body.get("id") if "body" in locals() else None
+        }

--- a/main_test.py
+++ b/main_test.py
@@ -1,0 +1,67 @@
+"""
+Ultra-minimal MCP server for Smithery testing.
+Returns tools in the simplest possible format.
+"""
+from fastapi import FastAPI, Request
+import json
+
+app = FastAPI()
+
+# Define tools in the simplest format
+TOOLS = [
+    {
+        "name": "get_player_stats",
+        "description": "Get player stats",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "required": ["name"]
+        }
+    }
+]
+
+@app.get("/health")
+async def health():
+    return {"status": "healthy"}
+
+@app.post("/")
+async def handle_request(request: Request):
+    """Handle all MCP requests"""
+    body = await request.json()
+    method = body.get("method")
+    request_id = body.get("id")
+    
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "mlb_mcp", "version": "1.0.0"}
+            },
+            "id": request_id
+        }
+    
+    elif method == "tools/list":
+        return {
+            "jsonrpc": "2.0",
+            "result": {"tools": TOOLS},
+            "id": request_id
+        }
+    
+    elif method == "tools/call":
+        return {
+            "jsonrpc": "2.0",
+            "result": {
+                "content": [{"type": "text", "text": "Test response"}]
+            },
+            "id": request_id
+        }
+    
+    return {
+        "jsonrpc": "2.0",
+        "error": {"code": -32601, "message": "Method not found"},
+        "id": request_id
+    }

--- a/smithery-dynamic.yaml
+++ b/smithery-dynamic.yaml
@@ -1,0 +1,33 @@
+# Smithery configuration file - Dynamic tools version
+name: mlb_mcp
+displayName: "MLB Baseball Stats API"
+description: "MCP server exposing MLB/Fangraphs data via pybaseballstats. Access player statistics, team data, and leaderboards."
+author: jweingardt12
+tags: ["sports", "baseball", "mlb", "statistics"]
+
+runtime: container
+
+# Server configuration
+server:
+  healthcheck:
+    path: /health
+    interval: 30s
+    timeout: 10s
+    initialDelaySeconds: 10
+  
+# Resource limits
+resources:
+  limits:
+    memory: "512Mi"
+    cpu: "500m"
+  requests:
+    memory: "256Mi"
+    cpu: "250m"
+
+# Start command
+startCommand:
+  type: "http"
+  configSchema:
+    type: "object"
+    properties: {}
+  exampleConfig: {}

--- a/smithery-test.yaml
+++ b/smithery-test.yaml
@@ -1,0 +1,26 @@
+# Minimal Smithery configuration for testing
+name: mlb_mcp
+displayName: "MLB Baseball Stats API"
+description: "MCP server exposing MLB/Fangraphs data via pybaseballstats"
+author: jweingardt12
+tags: ["sports", "baseball", "mlb", "statistics"]
+
+runtime: container
+
+server:
+  healthcheck:
+    path: /health
+    interval: 30s
+    timeout: 10s
+
+resources:
+  limits:
+    memory: "256Mi"
+    cpu: "250m"
+
+startCommand:
+  type: "http"
+  configSchema:
+    type: "object"
+    properties: {}
+  exampleConfig: {}


### PR DESCRIPTION
## Summary
- Created minimal test implementation to debug Smithery tool listing issue
- Includes ultra-simple MCP server with just one tool
- Proper PORT environment variable handling in Dockerfile

## Test files created
- `main_test.py` - Minimal MCP server with single tool
- `Dockerfile.test` - Simple Dockerfile with PORT handling
- `smithery-test.yaml` - Config without static tool definitions

## Next steps
Try deploying with these test files to see if tools list properly on Smithery.